### PR TITLE
[Board] Basic row-clearing and updating

### DIFF
--- a/tile_map.gd
+++ b/tile_map.gd
@@ -1,36 +1,84 @@
 class_name Board
 extends TileMap
 
-var x_pos = 0
-var y_pos = 0
-var er = false
+# Local variables.
+var dimensions = Vector2i(10, 20)
+var board = []
+
 
 ## Called when the node enters the scene tree for the first time.
 func _ready():
-    x_pos = 0
-    y_pos = 0
-    set_cell(0, Vector2i(x_pos, y_pos), 0, Vector2i(0,0), 0)
+	for x in range(dimensions.x):
+		board.append(Array())
+		for y in range(dimensions.y):
+			board[x].append(0)
+	var used_cells = get_used_cells(0)
+	for cell in used_cells:
+		board[cell.x][cell.y] = true
 
-## Updates the board.
-func Board_update():
-    pass
 
-## Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-    # Process 10 tiles at a time. Looping draw/erase.
-    for i in range(10):
-        y_pos = (y_pos + 1)
-        
-        if (y_pos > 40):
-            y_pos = 0
-            x_pos += 1
-            
-        if (x_pos > 30):
-            x_pos = 0
-            y_pos = 0
-            er = not er
+## Checks if the given row is full.
+func Board_isRowFull(row: int) -> bool:
+	var is_full = true
+	for cols in dimensions.x:
+		is_full = is_full and board[cols][row]
+	return is_full
 
-        if (er):
-            erase_cell(0, Vector2i(x_pos, y_pos))
-        else:
-            set_cell(0, Vector2i(x_pos, y_pos), 0, Vector2i(0,0), 0)
+
+## Clears the given row.
+func Board_clearRow(row: int):
+	for cols in dimensions.x:
+		board[cols][row] = false
+		erase_cell(0, Vector2i(cols, row))
+
+
+## Recursively updates the board given a starting row. A step size can be
+## optionally provided.
+## TODO(nkuang): default step to 1 as an optional parameter.
+func Board_updateRow(row: int, step: int):
+	if row < 0:
+		return
+	else:
+		for cols in dimensions.x:
+			if board[cols][row]:
+				board[cols][row] = false
+				var new_row = row + step
+				board[cols][new_row] = true
+				set_cell(
+					0,
+					Vector2i(cols, new_row),
+					get_cell_source_id(0, Vector2i(cols, row)),
+					Vector2i(0, 0),
+					0
+				)
+				erase_cell(0, Vector2i(cols, row))
+		Board_updateRow(row - 1, step)
+
+
+## Piece processing logic when we need to update the board state.
+func Board_playTiles():
+	# Testing clearing by hardcoding a 5-high I block with base at (8, 19).
+	var hardcode_block_x = 8
+	var hardcode_block_y = 19
+
+	# Rendering.
+	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y), 0, Vector2i(0, 0), 0)
+	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 1), 0, Vector2i(0, 0), 0)
+	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 2), 0, Vector2i(0, 0), 0)
+	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 3), 0, Vector2i(0, 0), 0)
+	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 4), 0, Vector2i(0, 0), 0)
+	board[hardcode_block_x][hardcode_block_y] = true
+	board[hardcode_block_x][hardcode_block_y - 1] = true
+	board[hardcode_block_x][hardcode_block_y - 2] = true
+	board[hardcode_block_x][hardcode_block_y - 3] = true
+	board[hardcode_block_x][hardcode_block_y - 4] = true
+
+	var rows_processed = 0
+
+	# Processing from the bottom to the top.
+	while rows_processed < hardcode_block_y:
+		if Board_isRowFull(hardcode_block_y - rows_processed):
+			Board_clearRow(hardcode_block_y - rows_processed)
+			Board_updateRow(hardcode_block_y - rows_processed, 1)
+		else:
+			rows_processed += 1

--- a/tile_map.gd
+++ b/tile_map.gd
@@ -66,28 +66,12 @@ func Board_updateRow(row: int, step: int):
 
 ## Piece processing logic when we need to update the board state.
 func Board_playTiles():
-	# Testing clearing by hardcoding a 5-high I block with base at (8, 19).
-	var hardcode_block_x = 8
-	var hardcode_block_y = 19
-
-	# Rendering.
-	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y), 0, Vector2i(0, 0), 0)
-	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 1), 0, Vector2i(0, 0), 0)
-	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 2), 0, Vector2i(0, 0), 0)
-	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 3), 0, Vector2i(0, 0), 0)
-	set_cell(0, Vector2i(hardcode_block_x, hardcode_block_y - 4), 0, Vector2i(0, 0), 0)
-	board[hardcode_block_x][hardcode_block_y] = true
-	board[hardcode_block_x][hardcode_block_y - 1] = true
-	board[hardcode_block_x][hardcode_block_y - 2] = true
-	board[hardcode_block_x][hardcode_block_y - 3] = true
-	board[hardcode_block_x][hardcode_block_y - 4] = true
-
 	var rows_processed = 0
-
+	var bottom_most_row = dimensions.y - 1
 	# Processing from the bottom to the top.
-	while rows_processed < hardcode_block_y:
-		if Board_isRowFull(hardcode_block_y - rows_processed):
-			Board_clearRow(hardcode_block_y - rows_processed)
-			Board_updateRow(hardcode_block_y - rows_processed, 1)
+	while rows_processed < bottom_most_row:
+		if Board_isRowFull(bottom_most_row - rows_processed):
+			Board_clearRow(bottom_most_row - rows_processed)
+			Board_updateRow(bottom_most_row - rows_processed, 1)
 		else:
 			rows_processed += 1

--- a/tile_map.gd
+++ b/tile_map.gd
@@ -2,7 +2,11 @@ class_name Board
 extends TileMap
 
 # Local variables.
+
+# Game dimensions.
 var dimensions = Vector2i(10, 20)
+
+# 2D game board to store piece positions and state.
 var board = []
 
 
@@ -12,6 +16,7 @@ func _ready():
 		board.append(Array())
 		for y in range(dimensions.y):
 			board[x].append(0)
+	# Mark all currently used cells in the board with their coordinates.
 	var used_cells = get_used_cells(0)
 	for cell in used_cells:
 		board[cell.x][cell.y] = true
@@ -36,14 +41,17 @@ func Board_clearRow(row: int):
 ## optionally provided.
 ## TODO(nkuang): default step to 1 as an optional parameter.
 func Board_updateRow(row: int, step: int):
+	# Recursion base case.
 	if row < 0:
 		return
 	else:
 		for cols in dimensions.x:
+			# We only need to update a piece if it exists.
 			if board[cols][row]:
 				board[cols][row] = false
 				var new_row = row + step
 				board[cols][new_row] = true
+				# Update by rendering the new position and erasing the old.
 				set_cell(
 					0,
 					Vector2i(cols, new_row),
@@ -52,6 +60,7 @@ func Board_updateRow(row: int, step: int):
 					0
 				)
 				erase_cell(0, Vector2i(cols, row))
+		# Process the rows above.
 		Board_updateRow(row - 1, step)
 
 

--- a/tile_map.tscn
+++ b/tile_map.tscn
@@ -5,6 +5,7 @@
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_gyxo3"]
 texture = ExtResource("1_fk3gp")
+texture_region_size = Vector2i(32, 32)
 0:0/0 = 0
 1:0/0 = 0
 2:0/0 = 0
@@ -263,10 +264,16 @@ texture = ExtResource("1_fk3gp")
 15:15/0 = 0
 
 [sub_resource type="TileSet" id="TileSet_8s885"]
+tile_size = Vector2i(32, 32)
 sources/0 = SubResource("TileSetAtlasSource_gyxo3")
 
 [node name="TileMap" type="TileMap"]
 tile_set = SubResource("TileSet_8s885")
 format = 2
-layer_0/tile_data = PackedInt32Array(2359324, 0, 0, 2228252, 0, 0, 2293788, 0, 1, 2097180, 0, 0, 2162716, 0, 1, 1966108, 0, 0, 2031644, 0, 1, 1835036, 0, 0, 1900572, 0, 1, 1376284, 0, 1)
 script = ExtResource("2_knasf")
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 2.0
+autostart = true
+
+[connection signal="timeout" from="Timer" to="." method="Board_playTiles"]


### PR DESCRIPTION
**Description:**

This PR adds basic piece clearing logic within the Tilemap node. The algorithm is pretty simple with the following steps:

1. Piece has just been placed on the board.
2. Start at the bottom-most row; check if the row is full.
3. If the row is full, clear it and subsequently update all of the rows above it. _Update in this case means shifting all of the blocks above the current row down by 1._
4. Repeat 2) and 3) for the rest of rows above.

A 2D array `grid` is used to update and track the coordinates of the pieces as they get placed and updated. Still more optimizations to do e.g. rendering but for now this is good enough.

**Testing (w/ @rp282):**

The following cases were tested by pre-placing tiles in the Tilemap scene and then spawning tiles s.t. a row is full and triggers clearing logic:
- Verified that multirow clearing works i.e. 5-high block clears 5 rows properly
- Verified that multirow clearing with gaps works i.e. 5 high block clears only full rows; rows with gaps do not get cleared
- Confirmed that certain configurations will result in floating pieces after updating. _This is a feature not a bug and is how normal Tetris behaves._